### PR TITLE
Reset writer to use object recusivly but not with comulative rows.

### DIFF
--- a/include/CSVWriter.h
+++ b/include/CSVWriter.h
@@ -144,6 +144,13 @@ class CSVWriter
         void disableAutoNewRow(){
             this->columnNum = -1;
         }
+        void resetContent(){
+             const static std::stringstream initial;
+
+            ss.str(std::string());
+            ss.clear();
+            ss.copyfmt(initial)
+        }
     protected:
         std::string seperator;
         int columnNum;

--- a/include/CSVWriter.h
+++ b/include/CSVWriter.h
@@ -144,13 +144,17 @@ class CSVWriter
         void disableAutoNewRow(){
             this->columnNum = -1;
         }
+       //you can use this reset method in destructor if you gonna use it in heap mem.
         void resetContent(){
              const static std::stringstream initial;
 
             ss.str(std::string());
             ss.clear();
-            ss.copyfmt(initial)
+            ss.copyfmt(initial);
         }
+      ~CSVWriter(){
+          resetContent();
+       }
     protected:
         std::string seperator;
         int columnNum;


### PR DESCRIPTION
just added reset method and could be used in the destruct-or !